### PR TITLE
fix: fix editlink not working, adjust sidebar order

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -14,6 +14,12 @@ module.exports = {
     docsBranch: 'main',
     editLinks: true,
     editLinkText: '为此页提供修改建议',
+
+    carbonAds: {
+      carbon: 'CEBIEK3N',
+      placement: 'vitejsdev'
+    },
+
     nav: [
       { text: '指引', link: '/guide/' },
       { text: '配置', link: '/config/' },
@@ -34,12 +40,12 @@ module.exports = {
             link: 'https://github.com/vitejs/awesome-vite'
           },
           {
-            text: 'Rollup 插件兼容',
-            link: 'https://vite-rollup-plugins.patak.dev/'
-          },
-          {
             text: 'Dev.to 社区',
             link: 'https://dev.to/t/vite'
+          },
+          {
+            text: 'Rollup 插件兼容',
+            link: 'https://vite-rollup-plugins.patak.dev/'
           },
           {
             text: '更新日志',
@@ -50,13 +56,9 @@ module.exports = {
       }
     ],
 
-    carbonAds: {
-      carbon: 'CEBIEK3N',
-      placement: 'vitejsdev'
-    },
-
     sidebar: {
       '/config/': 'auto',
+      '/plugins': 'auto',
       // catch-all fallback
       '/': [
         {
@@ -112,10 +114,6 @@ module.exports = {
           text: 'API',
           children: [
             {
-              text: '配置参考',
-              link: '/config/'
-            },
-            {
               text: '插件 API',
               link: '/guide/api-plugin'
             },
@@ -126,6 +124,10 @@ module.exports = {
             {
               text: 'JavaScript API',
               link: '/guide/api-javascript'
+            },
+            {
+              text: '配置参考',
+              link: '/config/'
             }
           ]
         }

--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -5,10 +5,13 @@
  */
 module.exports = {
   title: 'Vite',
-  lang: "zh-CN",
+  lang: 'zh-CN',
   description: '下一代前端开发与构建工具',
   head: [['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }]],
   themeConfig: {
+    repo: 'vitejs/docs-cn',
+    logo: '/logo.svg',
+    docsBranch: 'main',
     editLinks: true,
     editLinkText: '为此页提供修改建议',
     nav: [
@@ -34,7 +37,7 @@ module.exports = {
             text: 'Rollup 插件兼容',
             link: 'https://vite-rollup-plugins.patak.dev/'
           },
-           {
+          {
             text: 'Dev.to 社区',
             link: 'https://dev.to/t/vite'
           },
@@ -128,5 +131,5 @@ module.exports = {
         }
       ]
     }
-  },
-};
+  }
+}


### PR DESCRIPTION
1. 修复当前中文文档 editLink 不工作的问题（英文文档是工作的）：

before：
![image](https://user-images.githubusercontent.com/38436475/108341961-32f92300-7215-11eb-8ee5-1145370732f0.png)
after：
![image](https://user-images.githubusercontent.com/38436475/108341911-24ab0700-7215-11eb-98d5-b89b7b95558a.png)

2. 调整 sidebar 的顺序以保证与英文文档一致：

before：
![image](https://user-images.githubusercontent.com/38436475/108342153-6f2c8380-7215-11eb-8ecb-5ce0d4dc11fb.png)
after（「配置参考」在最下面，与英文文档一致）：
![image](https://user-images.githubusercontent.com/38436475/108342220-83708080-7215-11eb-9186-5a67cfede4a8.png)

3. 此外是一些无关紧要的格式化（vscode 按照 vite 的标准格式化的），与配置的顺序调整（尽可能与英文文档保持一致）