### PR TITLE
chore: omitted semantic release type (style) and changed all fullwidth brackets to halfwidth

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -4,6 +4,7 @@
  * @type {import('vitepress').UserConfig}
  */
 module.exports = {
+  hmr: { overlay: false },
   title: 'Vite',
   lang: 'zh-CN',
   description: '下一代前端开发与构建工具',

--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -4,7 +4,6 @@
  * @type {import('vitepress').UserConfig}
  */
 module.exports = {
-  hmr: { overlay: false },
   title: 'Vite',
   lang: 'zh-CN',
   description: '下一代前端开发与构建工具',

--- a/scripts/verifyCommit.js
+++ b/scripts/verifyCommit.js
@@ -5,7 +5,7 @@ const msgPath = process.env.GIT_PARAMS
 const msg = require('fs').readFileSync(msgPath, 'utf-8').trim()
 
 const releaseRE = /^v\d/
-const commitRE = /^(revert: )?(feat|fix|docs|typo|dx|refactor|perf|test|workflow|build|ci|chore|types|wip|release|deps)(\(.+\))?: .{1,50}/
+const commitRE = /^(revert: )?(feat|fix|style|docs|typo|dx|refactor|perf|test|workflow|build|ci|chore|types|wip|release|deps)(\(.+\))?: .{1,50}/
 
 if (!releaseRE.test(msg) && !commitRE.test(msg)) {
   console.log()

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,3 @@
+export default {
+  hmr: { overlay: false }
+}


### PR DESCRIPTION
在 `scripts/verifyCommit.js` 中加入了应该是遗漏了的 `style` 选项；应 wiki 的要求改变了所有的全角括号。

---

说到 semantic release，因为现在有些不规范，我写了些关于它的信息可以加入 wiki：
 
格式：`<type>(<scope>): <subject>`（`<scope>` 是可选的）

## 示范

```
feat: add good shit
^--^  ^------------^
|     |
|     +-> Summary in present tense.
|
+-------> Type: chore, docs, feat, fix, refactor, style, or test.
```

## 释义

- feat: (新功能，面向用户)
- fix: (bug 修复，面向用户)
- docs: (编辑文档)
- style: (格式，如全角半角；没有 production code 方面的改变)
- refactor: (比如重命名变量)
- test: (加入缺少的测试，没有 production code 方面的改变)
- chore: (更新依赖等，没有 production code 方面的改变)

## 参考

https://www.conventionalcommits.org/