### PR TITLE
docs: fix type in [Env Variables and Modes] page

### DIFF
--- a/guide/env-and-mode.md
+++ b/guide/env-and-mode.md
@@ -54,7 +54,7 @@ VITE_SOME_KEY=123
 
 ## 模式
 
-默认情况下，开发服务器 (`serve` 命令) 运行在 `development` （开发）模式，而 `build` 命令运行在 `production` （生产）模式。
+默认情况下，开发服务器 (`dev` 命令) 运行在 `development` （开发）模式，而 `build` 命令运行在 `production` （生产）模式。
 
 这意味着当执行 `vite build` 时，它会自动加载 `.env.production` 中可能存在的环境变量：
 


### PR DESCRIPTION
```diff
- 默认情况下，开发服务器 (`serve` 命令) 运行在 `development` （开发）模式，而 `build` 命令运行在 `production` （生产）模式。
+ 默认情况下，开发服务器 (`dev` 命令) 运行在 `development` （开发）模式，而 `build` 命令运行在 `production` （生产）模式。
```

When using the `serve` command, it is actually in production mode, here should be the `dev` command.