### PR TITLE
docs: show Chinese search results only

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -20,8 +20,8 @@ module.exports = {
     algolia: {
       apiKey: 'b573aa848fd57fb47d693b531297403c',
       indexName: 'vitejs',
-      algoliaOptions: {
-        'facetFilters': ["tags:cn"]
+      searchParameters: {
+        facetFilters: ['tags:cn']
       },
     },
 


### PR DESCRIPTION

![Screen Shot 2021-04-15 at 14 16 01](https://user-images.githubusercontent.com/664177/114867438-1d5b4080-9df5-11eb-9a08-b74d77cbc8a8.png)

Try searching `define` in the currently deployed version and this preview and you will see the difference

https://deploy-preview-82--vitejs-docs-cn.netlify.app/