### PR TITLE
chore: add rewrite title helper script.

### DIFF
--- a/.vitepress/rewrite-title/index.js
+++ b/.vitepress/rewrite-title/index.js
@@ -1,0 +1,57 @@
+const path = require('path')
+const fs = require('fs')
+const workspacePath = path.resolve(__dirname, '..', '..')
+const articleDirs = ['blog', 'config', 'guide', 'plugins']
+const h1MdRegExp = /^#\s+(.+)\s+(\{#([\w-]+)\})$/
+
+const rewriteMarkdownTitle = (filePath) => {
+  fs.readFile(filePath, (err, fileData) => {
+    if (err) {
+      console.warn(`Reading file: ${filePath} failed !`)
+      return
+    }
+
+    const lines = String(fileData).split(/\r?\n/)
+    if (h1MdRegExp.test(lines[0])) {
+      const matched = h1MdRegExp.exec(lines[0])
+      const titleMeta = `---\ntitle: ${matched[1]}\n---\n`
+      fs.writeFile(filePath, titleMeta + fileData, (err) => {
+        if (err) {
+          console.warn(`Writing title meta ${matched[1]} failed !`)
+          return
+        }
+      })
+    }
+  })
+}
+
+const ergodicDirectory = (dirPath) => {
+  fs.readdir(dirPath, (err, files) => {
+    if (err) {
+      console.warn('Directory reading failed !')
+      return
+    }
+
+    files.forEach((file) => {
+      const filePath = path.join(dirPath, file)
+      fs.stat(filePath, (err, stats) => {
+        if (err) {
+          console.warn('File status reading failed !')
+          return
+        }
+
+        if (stats.isFile()) {
+          if (filePath.split('.').pop().toLowerCase() === 'md') {
+            rewriteMarkdownTitle(filePath)
+          }
+        } else if (stats.isDirectory()) {
+          if (articleDirs.includes(filePath.split('/').pop())) {
+            ergodicDirectory(filePath)
+          }
+        }
+      })
+    })
+  })
+}
+
+ergodicDirectory(workspacePath)

--- a/.vitepress/rewrite-title/index.js
+++ b/.vitepress/rewrite-title/index.js
@@ -1,28 +1,20 @@
 const path = require('path')
 const fs = require('fs')
+const matterService = require('../utils/frontmatter-service')
 const workspacePath = path.resolve(__dirname, '..', '..')
-const articleDirs = ['blog', 'config', 'guide', 'plugins']
+
 const h1MdRegExp = /^#\s+(.+)\s+(\{#([\w-]+)\})$/
+/** 在此书写所有文章所在的目录名 */
+const articleDirs = ['blog', 'config', 'guide', 'plugins']
 
 const rewriteMarkdownTitle = (filePath) => {
-  fs.readFile(filePath, (err, fileData) => {
-    if (err) {
-      console.warn(`Reading file: ${filePath} failed !`)
-      return
-    }
+  const matter = matterService.open(filePath)
+  const lines = String(matter.file).split(/\r?\n/)
+  const h1Line = lines.find((line) => h1MdRegExp.test(line))
+  if (!h1Line) return
 
-    const lines = String(fileData).split(/\r?\n/)
-    if (h1MdRegExp.test(lines[0])) {
-      const matched = h1MdRegExp.exec(lines[0])
-      const titleMeta = `---\ntitle: ${matched[1]}\n---\n`
-      fs.writeFile(filePath, titleMeta + fileData, (err) => {
-        if (err) {
-          console.warn(`Writing title meta ${matched[1]} failed !`)
-          return
-        }
-      })
-    }
-  })
+  const title = h1MdRegExp.exec(h1Line)[1]
+  matter.set('title', title).save()
 }
 
 const ergodicDirectory = (dirPath) => {

--- a/.vitepress/utils/frontmatter-service.js
+++ b/.vitepress/utils/frontmatter-service.js
@@ -1,0 +1,66 @@
+const fs = require('fs')
+const matter = require('gray-matter')
+const { extend, isEmpty: _isEmpty } = require('lodash')
+// gray-matter is a dep for vitepress,
+// no need to specify that in package.json
+
+class FrontMatterService {
+  constructor() {}
+
+  /** @param {Record<string, any>} obj */
+  __print(obj) {
+    console.log(JSON.stringify(obj, null, 2))
+  }
+
+  /** @param {string} filePath */
+  open(filePath) {
+    this.filePath = filePath
+    this.file = fs.readFileSync(filePath)
+    this.matter = matter(String(this.file))
+    return this
+  }
+
+  isEmpty() {
+    return _isEmpty(this.matter.data)
+  }
+
+  /** @param{(data: string) => void} callback */
+  readFile(callback) {
+    callback(String(this.file))
+    return this
+  }
+
+  /** @param {string} string */
+  show(key) {
+    let output = flag ? this.matter[key] : this.matter
+    this.__print(output)
+    return this
+  }
+
+  /**
+   * @param {string} key
+   * @param {string} value
+   * */
+  set(key, value) {
+    this.matter.data[key] = value
+    return this
+  }
+
+  /** @param {Record<string, any>} src */
+  extend(src) {
+    extend(this.matter.data, src)
+    return this
+  }
+
+  save() {
+    let matterStringifyData = this.matter.stringify()
+    fs.writeFile(this.filePath, matterStringifyData, (err) => {
+      if (err) {
+        console.warn(`${this.filePath} -- Saving file with matter failed !!`)
+        return
+      }
+    })
+  }
+}
+
+module.exports = new FrontMatterService()

--- a/index.md
+++ b/index.md
@@ -1,35 +1,35 @@
 ---
 home: true
 heroImage: /logo.svg
-actionText: Get Started
+actionText: 开始
 actionLink: /guide/
 
-altActionText: Learn More
+altActionText: 了解更多
 altActionLink: /guide/why
 
 features:
-  - title: 💡 Instant Server Start
-    details: On demand file serving over native ESM, no bundling required!
-  - title: ⚡️ Lightning Fast HMR
-    details: Hot Module Replacement (HMR) that stays fast regardless of app size.
-  - title: 🛠️ Rich Features
-    details: Out-of-the-box support for TypeScript, JSX, CSS and more.
-  - title: 📦 Optimized Build
-    details: Pre-configured Rollup build with multi-page and library mode support.
-  - title: 🔩 Universal Plugins
-    details: Rollup-superset plugin interface shared between dev and build.
-  - title: 🔑 Fully Typed APIs
-    details: Flexible programmatic APIs with full TypeScript typing.
+  - title: 💡 极速的服务启动
+    details: 使用原生 ESM 文件，无需打包!
+  - title: ⚡️ 轻量快速的热重载
+    details: 无论应用程序大小如何，都始终极快的模块热重载（HMR）
+  - title: 🛠️ 丰富的功能
+    details: 对 TypeScript、JSX、CSS 等支持开箱即用。
+  - title: 📦 优化的构建
+    details: 可选 “多页应用” 或 “库” 模式的预配置 Rollup 构建
+  - title: 🔩 通用的插件
+    details: 在开发和构建之间共享 Rollup-superset 插件接口。
+  - title: 🔑 完全类型化的API
+    details: 灵活的 API 和完整 TypeScript 类型。
 footer: MIT Licensed | Copyright © 2019-present Evan You & Vite Contributors
 ---
 
 <div class="frontpage sponsors">
-  <h2>Sponsors</h2>
+  <h2>赞助</h2>
   <a v-for="{ href, src, name } of sponsors" :href="href" target="_blank" rel="noopener" aria-label="sponsor-img">
     <img :src="src" :alt="name">
   </a>
   <br>
-  <a href="https://github.com/sponsors/yyx990803" target="_blank" rel="noopener">Become a sponsor on GitHub</a>
+  <a href="https://github.com/sponsors/yyx990803" target="_blank" rel="noopener">在 GitHub 上赞助我们</a>
 </div>
 
 <script setup>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"scripts": {
 		"dev": "vitepress dev .",
-		"build": "vitepress build .",
+		"build": "node ./.vitepress/rewrite-title/ && vitepress build .",
 		"serve": "vitepress serve ."
 	},
 	"gitHooks": {


### PR DESCRIPTION
# 更改标题的帮手脚本

由于目前文档结构中：
```
const articleDirs = ['blog', 'config', 'guide', 'plugins']
```
仅有这几个文件夹中的数篇文档内容形式以 `# xxx` 的一级标题开头，而根目录的两篇 `index.md` 和 `README.md` 都不是这样。
所以我们采取的办法是：

**在 `vitepress build` 前运行追加 title meta 的过程。**
这样构建出来的产物每一页的标题都不会是 `开始 {#getting-started} | Vite 中文文档` 的样子了。