### PR TITLE
docs(cn): fix translation error about lib mode

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -556,7 +556,7 @@ createServer()
   小于此阈值的导入或引用资源将内联为 base64 编码，以避免额外的 http 请求。设置为 `0` 可以完全禁用此项。
 
   :::tip 注意
-  无论文件大小，资源都会被内联，如果你指定了 `build.assetsInlineLimit`，那么 `build.lib` 将被忽略。
+  如果你指定了 `build.lib`，那么 `build.assetsInlineLimit` 将被忽略,无论文件大小，资源都会被内联。
   :::
 
 ### build.cssCodeSplit {#build-csscodesplit}

--- a/config/index.md
+++ b/config/index.md
@@ -556,7 +556,7 @@ createServer()
   小于此阈值的导入或引用资源将内联为 base64 编码，以避免额外的 http 请求。设置为 `0` 可以完全禁用此项。
 
   :::tip 注意
-  如果你指定了 `build.lib`，那么 `build.assetsInlineLimit` 将被忽略,无论文件大小，资源都会被内联。
+  如果你指定了 `build.lib`，那么 `build.assetsInlineLimit` 将被忽略，无论文件大小，资源都会被内联。
   :::
 
 ### build.cssCodeSplit {#build-csscodesplit}


### PR DESCRIPTION
这句明显和英文文档相悖。并且也不符合事实

> Assets will always be inlined, regardless of file size, and build.assetsInlineLimit will be ignored if you specify build.lib

同时也不符合代码的表现

>  in vite/src/node/plugins/asset.ts/fileToBuiltUrl line 211

``` js
  let url
  if (
    config.build.lib || // 使用了lib模式就无视
    (!file.endsWith('.svg') &&
      content.length < Number(config.build.assetsInlineLimit)) // 这里是判断 assetsInlineLimit 与资源的大小
  ) {
    // base64 inlined as a string
    url = `data:${mime.getType(file)};base64,${content.toString('base64')}`
  } else {
```