### PR TITLE
docs(cn): fix rollup plugin compatibility anchor

### DIFF
--- a/guide/api-plugin.md
+++ b/guide/api-plugin.md
@@ -6,7 +6,7 @@ Vite 插件扩展了设计出色的 Rollup 接口，带有一些 Vite 独有的�
 
 ## 约定 {#conventions}
 
-如果插件不使用 Vite 特有的钩子，可以实现为 [兼容的 Rollup 插件](#Rollup-插件兼容性)，推荐使用 [Rollup 插件名称约定](https://rollupjs.org/guide/en/#conventions)。
+如果插件不使用 Vite 特有的钩子，可以实现为 [兼容的 Rollup 插件](#rollup-plugin-compatibility)，推荐使用 [Rollup 插件名称约定](https://rollupjs.org/guide/en/#conventions)。
 
 - Rollup 插件应该有一个带 `rollup-plugin-` 前缀、语义清晰的名称。
 - 在 package.json 中包含 `rollup-plugin` 和 `vite-plugin` 关键字。


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42465692/124882348-ddc28000-e002-11eb-88fa-99f3a9f28eb4.png)
现在线上文档https://cn.vitejs.dev/guide/api-plugin.html#conventions ，在点击「兼容的 Rollup 插件」这个锚点时无法跳转到对应的章节，英文版没有这个问题，中文版会有，修改md中的链接以使能跳转
