### PR TITLE
fix: 修正releaseTagName取不到导致前端显示undefined的问题

### DIFF
--- a/.vitepress/theme/fetchReleaseTag.js
+++ b/.vitepress/theme/fetchReleaseTag.js
@@ -13,8 +13,9 @@ export default function fetchReleaseTag() {
         const releaseTagName = json.tag_name
         docsReleaseTag.innerText = releaseTagName
 
-
-        mainTitle.appendChild(docsReleaseTag)
+        if (releaseTagName !== undefined) {
+          mainTitle.appendChild(docsReleaseTag)
+        }
       })
   })
 }


### PR DESCRIPTION
当`https://api.github.com/repos/vitejs/docs-cn/releases/latest`这个接口被限频时，拿不到tag_name，会导致vite前端的版本显示undefined，这里做一下兜底处理，当拿不到tag_name的时候，不显示tag_name

<img width="1900" alt="截屏2021-07-08 18 07 46" src="https://user-images.githubusercontent.com/29225966/124904265-6814df00-e017-11eb-851f-01fd199f104d.png">
