### PR TITLE
"Edit page" GitHub link points to incorrect path

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
 
     editLink: {
       text: '为此页提供修改建议',
-      pattern: 'https://github.com/vitejs/docs-cn/edit/main/docs/:path',
+      pattern: 'https://github.com/vitejs/docs-cn/edit/main/:path',
     },
 
     socialLinks: [


### PR DESCRIPTION
`vitejs/vite` had all paths nested under `docs/` which is not needed here. I have removed that.