### PR TITLE
fix(build): 修复 配置 -> 构建配置 页面404

### DIFF
--- a/.vitepress/markdown-it-custom-anchor/index.js
+++ b/.vitepress/markdown-it-custom-anchor/index.js
@@ -11,15 +11,4 @@ export default function(md) {
     const titleAndId = oldTitle(tokens, idx, options, env, slf);
     return removeAnchorFromTitle(titleAndId);
   };
-
-  const oldHeading = md.renderer.rules.heading_open;
-  md.renderer.rules.heading_open = (tokens, idx, options, env, slf) => {
-    const head = oldHeading(tokens, idx, options, env, slf);
-    const data = md.__data;
-    const headers = data.headers || (data.headers = []);
-    headers.forEach(element => {
-      element.title = removeAnchorFromTitle(element.title);
-    });
-    return head;
-  }
 };


### PR DESCRIPTION
在 vitepress 的 v1.0.0-alpha.11 中删除了内置的 headings 插件，导致 md.renderer.rules.heading_open 方法不可用，所以 配置 - 构建配置页面 404 了。

关联问题 #608