### PR TITLE
docs: fix 672e43aa-1 branch conflict

### DIFF
--- a/config/build-options.md
+++ b/config/build-options.md
@@ -209,19 +209,15 @@ npm add -D terser
 
 默认情况下，若 `outDir` 在 `root` 目录下，则 Vite 会在构建时清空该目录。若 `outDir` 在根目录之外则会抛出一个警告避免意外删除掉重要的文件。可以设置该选项来关闭这个警告。该功能也可以通过命令行参数 `--emptyOutDir` 来使用。
 
-<<<<<<< HEAD
+## build.copyPublicDir {#build-copypublicdir}
+
+- **实验性特性**
+- **类型:** `boolean`
+- **默认:** `true`
+
+默认情况下，Vite 会在构建阶段将 `public` 目录中的所有文件复制到 `outDir` 目录中。可以通过设置该选项为 `false` 来禁用该行为。
+
 ## build.reportCompressedSize {#build-reportcompressedsize}
-=======
-## build.copyPublicDir
-
-- **Experimental**
-- **Type:** `boolean`
-- **Default:** `true`
-
-By default, Vite will copy files from the `publicDir` into the `outDir` on build. Set to `false` to disable this.
-
-## build.reportCompressedSize
->>>>>>> 672e43aa80d4d1735cc86e6fa987da228f4fd517
 
 - **类型：** `boolean`
 - **默认：** `true`

--- a/config/build-options.md
+++ b/config/build-options.md
@@ -212,8 +212,8 @@ npm add -D terser
 ## build.copyPublicDir {#build-copypublicdir}
 
 - **实验性特性**
-- **类型:** `boolean`
-- **默认:** `true`
+- **类型：** `boolean`
+- **默认：** `true`
 
 默认情况下，Vite 会在构建阶段将 `publicDir` 目录中的所有文件复制到 `outDir` 目录中。可以通过设置该选项为 `false` 来禁用该行为。
 

--- a/config/build-options.md
+++ b/config/build-options.md
@@ -215,7 +215,7 @@ npm add -D terser
 - **类型:** `boolean`
 - **默认:** `true`
 
-默认情况下，Vite 会在构建阶段将 `public` 目录中的所有文件复制到 `outDir` 目录中。可以通过设置该选项为 `false` 来禁用该行为。
+默认情况下，Vite 会在构建阶段将 `publicDir` 目录中的所有文件复制到 `outDir` 目录中。可以通过设置该选项为 `false` 来禁用该行为。
 
 ## build.reportCompressedSize {#build-reportcompressedsize}
 

--- a/guide/why.md
+++ b/guide/why.md
@@ -51,11 +51,7 @@ Vite 同时利用 HTTP 头来加速整个页面的重新加载（再次让浏览
 
 ### 为何不用 ESBuild 打包？ {#why-not-bundle-with-esbuild}
 
-<<<<<<< HEAD
 虽然 `esbuild` 快得惊人，并且已经是一个在构建库方面比较出色的工具，但一些针对构建 _应用_ 的重要功能仍然还在持续开发中 —— 特别是代码分割和 CSS 处理方面。就目前来说，Rollup 在应用打包方面更加成熟和灵活。尽管如此，当未来这些功能稳定后，我们也不排除使用 `esbuild` 作为生产构建器的可能。
-=======
-While `esbuild` is extremely fast and is already a very capable bundler for libraries, some of the important features needed for bundling _applications_ are still work in progress - in particular code-splitting and CSS handling. For the time being, Rollup is more mature and flexible in these regards. That said, we won't rule out the possibility of using `esbuild` for production builds when it stabilizes these features in the future.
->>>>>>> 672e43aa80d4d1735cc86e6fa987da228f4fd517
 
 ## Vite 与 X 的区别是？ {#how-is-vite-different-from-x}
 


### PR DESCRIPTION
guide/why 只是将描述 esbuild 快的措辞从 `blazing` 到了 `extremely`，所以我认为中文释义保持不变即可