### PR TITLE
Update dep-pre-bundling.md

### DIFF
--- a/guide/dep-pre-bundling.md
+++ b/guide/dep-pre-bundling.md
@@ -67,7 +67,7 @@ export default defineConfig({
 
 默认的依赖项发现为启发式可能并不总是可取的。在你想要显式地从列表中包含/排除依赖项的情况下, 请使用 [`optimizeDeps` 配置项](/config/dep-optimization-options.md)。
 
-当你遇到不能直接在源码中发现的 import 时，`optimizeDeps.include` 或 `optimizeDeps.exclude` 就是典型的用例。例如，import 可能是插件转换的结果。这意味着 Vite 无法在初始扫描时发现 import —— 它只能在浏览器请求文件时转换后才能发现。这将导致服务器在启动后立即重新打包。
+`optimizeDeps.include` 或 `optimizeDeps.exclude` 的一个典型使用场景，是 Vite 在源码中不能直接发现 import 的时候。例如，import 可能是插件转换的结果。这意味着 Vite 无法在初始扫描时发现 import —— 它只能在浏览器请求文件时转换后才能发现。这将导致服务器在启动后立即重新打包。
 
 `include` 和 `exclude` 都可以用来处理这个问题。如果依赖项很大（包含很多内部模块）或者是 CommonJS，那么你应该包含它；如果依赖项很小，并且已经是有效的 ESM，则可以排除它，让浏览器直接加载它。
 

--- a/guide/dep-pre-bundling.md
+++ b/guide/dep-pre-bundling.md
@@ -67,7 +67,7 @@ export default defineConfig({
 
 默认的依赖项发现为启发式可能并不总是可取的。在你想要显式地从列表中包含/排除依赖项的情况下, 请使用 [`optimizeDeps` 配置项](/config/dep-optimization-options.md)。
 
-`optimizeDeps.include` 或 `optimizeDeps.exclude` 的一个典型使用场景，是 Vite 在源码中不能直接发现 import 的时候。例如，import 可能是插件转换的结果。这意味着 Vite 无法在初始扫描时发现 import —— 它只能在浏览器请求文件时转换后才能发现。这将导致服务器在启动后立即重新打包。
+`optimizeDeps.include` 或 `optimizeDeps.exclude` 的一个典型使用场景，是当 Vite 在源码中无法直接发现 import 的时候。例如，import 可能是插件转换的结果。这意味着 Vite 无法在初始扫描时发现 import —— 只能在文件被浏览器请求并转换后才能发现。这将导致服务器在启动后立即重新打包。
 
 `include` 和 `exclude` 都可以用来处理这个问题。如果依赖项很大（包含很多内部模块）或者是 CommonJS，那么你应该包含它；如果依赖项很小，并且已经是有效的 ESM，则可以排除它，让浏览器直接加载它。
 


### PR DESCRIPTION
原文：
当你遇到不能直接在源码中发现的 import 时，optimizeDeps.include 或 optimizeDeps.exclude 就是典型的用例。
A typical use case for optimizeDeps.include or optimizeDeps.exclude is when you have an import that is not directly discoverable in the source code.

我认为中文这样直接从英文翻译不太好理解，换一下语序会更好