### PR TITLE
fix: proview-options.md typo

### DIFF
--- a/config/preview-options.md
+++ b/config/preview-options.md
@@ -5,7 +5,7 @@
 - **类型：** `string | boolean`
 - **默认：** [`server.host`](#server_host)
 
-为开发服务器指定 ip 地址。
+为服务器指定 ip 地址。
 设置为 `0.0.0.0` 或 `true` 会监听所有地址，包括局域网和公共地址。
 
 还可以通过 CLI 进行设置，使用 `--host 0.0.0.0` 或 `--host`。
@@ -22,7 +22,7 @@
 - **类型：** `number`
 - **默认：** `4173`
 
-指定开发服务器端口。注意，如果设置的端口已被使用，Vite 将自动尝试下一个可用端口，所以这可能不是最终监听的服务器端口。
+指定服务器端口。注意，如果设置的端口已被使用，Vite 将自动尝试下一个可用端口，所以这可能不是最终监听的服务器端口。
 
 **示例：**
 
@@ -58,14 +58,14 @@ export default defineConfig({
 - **类型：** `boolean | string`
 - **默认：** [`server.open`](#server_open)
 
-开发服务器启动时，自动在浏览器中打开应用程序。当该值为字符串时，它将被用作 URL 的路径名。如果你想在你喜欢的某个浏览器打开该开发服务器，你可以设置环境变量 `process.env.BROWSER` （例如 `firefox`）。欲了解更多细节，请参阅 [`open` 包的源码](https://github.com/sindresorhus/open#app)。
+服务器启动时，自动在浏览器中打开应用程序。当该值为字符串时，它将被用作 URL 的路径名。如果你想在你喜欢的某个浏览器打开该服务器，你可以设置环境变量 `process.env.BROWSER` （例如 `firefox`）。欲了解更多细节，请参阅 [`open` 包的源码](https://github.com/sindresorhus/open#app)。
 
 ## preview.proxy {#preview-proxy}
 
 - **类型：** `Record<string, string | ProxyOptions>`
 - **默认：** [`server.proxy`](#server_proxy)
 
-为开发服务器配置自定义代理规则。其值的结构为 `{ key: options }` 的对象。如果 key 以 `^` 开头，它将被识别为 `RegExp`，其中 `configure` 选项可用于访问代理实例。
+为服务器配置自定义代理规则。其值的结构为 `{ key: options }` 的对象。如果 key 以 `^` 开头，它将被识别为 `RegExp`，其中 `configure` 选项可用于访问代理实例。
 
 基于 [`http-proxy`](https://github.com/http-party/node-http-proxy) 实现，完整的参数列表参见 [此链接](https://github.com/http-party/node-http-proxy#options)。
 
@@ -74,7 +74,7 @@ export default defineConfig({
 - **类型：** `boolean | CorsOptions`
 - **默认：** [`server.cors`](#server_proxy)
 
-为开发服务器配置 CORS。此功能默认启用并支持任何来源。可传递一个 [options 对象](https://github.com/expressjs/cors) 来进行配置，或者传递 `false` 来禁用此行为。
+为服务器配置 CORS。此功能默认启用并支持任何来源。可传递一个 [options 对象](https://github.com/expressjs/cors) 来进行配置，或者传递 `false` 来禁用此行为。
 
 ## preview.headers {#preview-headers}
 


### PR DESCRIPTION
在预览选项章节，许多 `服务器` 的措辞描述成 `开发服务器`，将其修正。