### PR TITLE
fix: `build.minify` force down to `es2021`

### DIFF
--- a/config/build-options.md
+++ b/config/build-options.md
@@ -10,7 +10,7 @@
 
 另一个特殊值是 “esnext” —— 即假设有原生动态导入支持，并且将会转译得尽可能小：
 
-- 如果 [`build.minify`](#build-minify) 选项为 `'terser'`，`'esnext'` 将会强制降级为 `'es2019'`。
+- 如果 [`build.minify`](#build-minify) 选项为 `'terser'`，`'esnext'` 将会强制降级为 `'es2021'`。
 - 其他情况下将完全不会执行转译。
 
 转换过程将会由 esbuild 执行，并且此值应该是一个合法的 [esbuild 目标选项](https://esbuild.github.io/api/#target)。自定义目标也可以是一个 ES 版本（例如：`es2015`）、一个浏览器版本（例如：`chrome58`）或是多个目标组成的一个数组。


### PR DESCRIPTION
https://github.com/vitejs/vite/blob/v4.0.4/packages/vite/src/node/build.ts#L367-L368

<img width="626" alt="image" src="https://user-images.githubusercontent.com/26263658/211298199-dac1bdef-96a8-4997-9625-486d9020c4c2.png">