### PR TITLE
feat: use new option for outline title

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -45,7 +45,9 @@ export default defineConfig({
       text: '为此页提供修改建议',
     },
     
-    outlineTitle: '本页目录',
+    outline: {
+      label: '本页目录'
+    },
 
     socialLinks: [
       { icon: 'twitter', link: 'https://twitter.com/vite_js' },


### PR DESCRIPTION
- [x] #694 

`outlineTitle` 已经在最新的版本中[废弃](https://github.com/vuejs/vitepress/commit/8de2f4499d9364d85e6070ce4b94651a1902b101#diff-08d1bb1c444a76199b8f44b087883f932a6f8118f5ded25bf5c508fa52aa5b7f)。

