### PR TITLE
fix: wrong translation

### DIFF
--- a/guide/ssr.md
+++ b/guide/ssr.md
@@ -239,7 +239,7 @@ export function mySSRPlugin() {
 }
 ```
 
-`options` 中的 `load` 和 `transform` 为可选项，rollup 目前并未使用该对象，但将来可能会用额外的元数据来扩展这些钩子函数。
+`load` 和 `transform` 中的 `options` 对象为可选项，rollup 目前并未使用该对象，但将来可能会用额外的元数据来扩展这些钩子函数。
 
 :::tip Note
 Vite 2.7 之前的版本，会提示你 `ssr` 参数的位置不应该是 `options` 对象。目前所有主要框架和插件都已对应更新，但你可能还是会发现使用过时 API 的旧文章。


### PR DESCRIPTION
[原文](https://vitejs.dev/guide/ssr.html#ssr-specific-plugin-logic)的描述是"The options object in load and transform is optional"，对应的中文翻译有误