### PR TITLE
vite build with worker format with es notice

### DIFF
--- a/guide/features.md
+++ b/guide/features.md
@@ -660,6 +660,7 @@ const worker = new Worker(new URL('./worker.js', import.meta.url), {
 ```
 
 只有在 `new Worker()` 声明中直接使用 `new URL()` 构造函数时，work 线程的检测才会生效。此外，所有选项参数必须是静态值（即字符串字面量）。
+注：如果默认Vite.config.ts打包时报错，新增worker.formate = "es",将worker独立文件打包为模块，不使用默认iief（该模式会添加document.style.....)。
 
 ### 带有查询后缀的导入 {#import-with-query-suffixes}
 


### PR DESCRIPTION
添加使用vite进行打包时遇到worker文件内报错解决提示，
原因为在默认iief模式下，worker子文件内会被加入document.style.......然后，worker环境内没有该对象，导致脚本不能正常运行。现阶找寻到的解决方案是将worker格式从默认iief变更为es。