### PR TITLE
chore(packageManager): lock in pnpm@8.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"vite": "^5.1.6",
 		"yorkie": "^2.0.0"
 	},
+	"packageManager": "pnpm@8.9.0",
 	"scripts": {
 		"dev": "vitepress dev .",
 		"build": "vitepress build .",


### PR DESCRIPTION
实际上应该像vite主仓库一样lock在9.5，但是目前lock文件变更会很大。主要原因是 pnpm8 和 pnpm9 文件格式变了，每行都会变更。

通过锁在8.x，使用corepack，可以避免安装依赖时起冲突

https://github.com/vitejs/vite/blob/main/package.json#L100C1-L100C34