### PR TITLE
fix(plugins): fix anchor point titles

### DIFF
--- a/plugins/index.md
+++ b/plugins/index.md
@@ -8,11 +8,11 @@ Vite 旨在为常见的 web 开发工作提供开箱即用的支持。在搜索�
 
 ## 官方插件 {#official-plugins}
 
-### [@vitejs/plugin-vue](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue) {#vitejsplugin-vue}
+### [@vitejs/plugin-vue](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue) {#vitejs-plugin-vue}
 
 - 提供 Vue 3 单文件组件支持。
 
-### [@vitejs/plugin-vue-jsx](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue-jsx) {#vitejsplugin-vue-jsx}
+### [@vitejs/plugin-vue-jsx](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue-jsx) {#vitejs-plugin-vue-jsx}
 
 - 提供 Vue 3 JSX 支持（通过 [专用的 Babel 转换插件](https://github.com/vuejs/jsx-next)）。
 
@@ -28,11 +28,11 @@ Vite 旨在为常见的 web 开发工作提供开箱即用的支持。在搜索�
 
 - 使用 esbuild 和 Babel，使用一个微小体积的包脚注可以实现极速的 HMR，同时提升灵活性，能够使用 Babel 的转换管线。在构建时没有使用额外的 Babel 插件，只使用了 esbuild。
 
-### [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) {#vitejsplugin-react-swc}
+### [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) {#vitejs-plugin-react-swc}
 
 - 在开发时会将 Babel 替换为 SWC。在构建时，若使用了插件则会使用 SWC+esbuild，若没有使用插件则仅会用到 esbuild。对不需要非标准 React 扩展的大型项目，冷启动和模块热替换（HMR）将会有显著提升。
 
-### [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) {#vitejsplugin-legacy}
+### [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) {#vitejs-plugin-legacy}
 
 - 为打包后的文件提供传统浏览器兼容性支持。
 


### PR DESCRIPTION
English docs：https://vitejs.dev/plugins/#vitejs-plugin-react-swc

Chinese docs：https://cn.vitejs.dev/plugins/#vitejsplugin-react-swc

The anchored document position is incorrect when switching from an English document to the corresponding Chinese document

![image](https://github.com/user-attachments/assets/abe290f7-e769-468c-8e12-34f0c1cda20e)
