### PR TITLE
docs(cn): Fix the wrong link

### DIFF
--- a/guide/migration.md
+++ b/guide/migration.md
@@ -151,4 +151,4 @@ Vite 6 扩展了对更多 HTML 元素的支持。完整列表请参见 [HTML 功
 
 ## 从 v4 迁移 {#migration-from-v4}
 
-在 Vite v5 文档中查看 [从 v4 迁移指南](https://v4.vite.dev/guide/migration.html)（[中文版](/guide/migration-from-v4)），了解如何将你的应用迁移到 Vite v5，然后再处理本页中所提及的变化。
+在 Vite v5 文档中查看 [从 v4 迁移指南](https://v5.vite.dev/guide/migration.html)（[中文版](/guide/migration-from-v4)），了解如何将你的应用迁移到 Vite v5，然后再处理本页中所提及的变化。


### PR DESCRIPTION
Fixed incorrect link in "Migrate from v4".
It should link to the migration page for v5.