### PR TITLE
docs(cn): update `Layout.vue` components of the sponsors content

### DIFF
--- a/.vitepress/theme/landing/Layout.vue
+++ b/.vitepress/theme/landing/Layout.vue
@@ -30,7 +30,11 @@ const { data: sponsors } = useSponsor()
   <HeadingSection heading="支持你喜爱的框架和工具" />
   <ViteFrameworks />
   <ViteCommunity />
-  <Sponsors :sponsors="sponsors" />
+  <Sponsors
+    heading="免费 & 开源"
+    sponsor-link-text="成为赞助商"
+    description="Vite 采用 MIT 许可协议，将始终保持免费开源。这得益于我们的贡献者及以下企业的支持："
+   :sponsors="sponsors" />
   <Spacer />
   <Footer
     heading="使用 Vite 开始构建"


### PR DESCRIPTION
## 更新范围
更新首页 `Sponsors` 组件相关翻译
<img width="2414" height="636" alt="image" src="https://github.com/user-attachments/assets/e825579a-25f3-4db2-89f7-a3060dea8990" />


`Sponsors` 组件在源码中暴漏了 `props`，类型签名如下所示：
```ts
interface Props {
  sponsors?: SponsorTier[]
  heading?: string
  description?: string
  sponsorLink?: string
  sponsorLinkText?: string
  sideBySideTiers?: [string, string] // e.g., ['bronze', 'backers'] for side-by-side layout
  logoStyle?: 'opencollective'
}
```
在 dom 部分是这样使用的
```html
<h3 class="text-white max-w-xl text-balance">{{ heading }}</h3>
<p class="max-w-lg text-white/70 text-balance">{{ description }}</p>
```



其他英文部分，在原 UI 库中直接写死了，不能通过 `props` 方式进行修改，但是可以考虑 `patch` 方案处理（这似乎不太合理）