### PR TITLE
docs(features): correct skipLibCheck value type

### DIFF
--- a/guide/features.md
+++ b/guide/features.md
@@ -118,7 +118,7 @@ Vite 忽略 `tsconfig.json` 中的 `target` 值，遵循与 [esbuild](https://es
 - [`experimentalDecorators`](https://www.typescriptlang.org/tsconfig#experimentalDecorators)
 
 ::: tip `skipLibCheck`
-Vite 启动模板默认情况下会设置 `"skipLibCheck": "true"`，以避免对依赖项进行类型检查，因为它们可能只支持特定版本和配置的 TypeScript。你可以在 [vuejs/vue-cli#5688](https://github.com/vuejs/vue-cli/pull/5688) 了解更多信息。
+Vite 启动模板默认情况下会设置 `"skipLibCheck": true`，以避免对依赖项进行类型检查，因为它们可能只支持特定版本和配置的 TypeScript。你可以在 [vuejs/vue-cli#5688](https://github.com/vuejs/vue-cli/pull/5688) 了解更多信息。
 :::
 
 ### 客户端类型 {#client-types}


### PR DESCRIPTION
`"true"` 带了双引号变成了字符串，应该是布尔值 `true`（英文原文也是 `true`）。