### PR TITLE
docs(guide): fix translation in api-javascript.md

### DIFF
--- a/guide/api-javascript.md
+++ b/guide/api-javascript.md
@@ -77,7 +77,7 @@ parentServer.use(vite.middlewares)
 
 ## `ResolvedConfig` {#resolvedconfig}
 
-`ResolvedConfig` 接口和 `UserConfig` 有完全相同的属性，期望多数属性是已经解析完成且不为 undefined 的。它同样包括下面这样的工具方法：
+`ResolvedConfig` 接口拥有和 `UserConfig` 完全相同的属性，但区别在于这些属性多数都已经被解析完成，并且不会是 `undefined`。它同样包括下面这样的工具方法：
 
 - `config.assetsInclude`：一个函数，用来检查一个 `id` 是否被考虑为是一个资源。
 - `config.logger`：Vite 内部的日志对象。


### PR DESCRIPTION
修正了误将原文 “except” 当作 “expect” 翻译成 "期望" 的问题，并且调整了整句话的措辞。