### PR TITLE
docs(home): localize trusted-by and sponsor sections

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -541,6 +541,10 @@ const config = defineConfig({
           import.meta.dirname,
           'theme/components/TopBanner.vue',
         ),
+        '@components/oss/TrustedBy.vue': path.resolve(
+          import.meta.dirname,
+          'theme/components/TrustedBy.vue',
+        ),
       },
     },
     plugins: [

--- a/.vitepress/theme/components/TrustedBy.vue
+++ b/.vitepress/theme/components/TrustedBy.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import LogoGrid from '@voidzero-dev/vitepress-theme/src/components/shared/LogoGrid.vue'
+
+const props = defineProps<{
+  logos: string[]
+}>()
+
+const logos = props.logos.map((name) => ({
+  src: `/trusted-by/${name}.svg`,
+  alt: name,
+}))
+</script>
+
+<template>
+  <section
+    class="wrapper wrapper--ticks border-t px-10 py-6 md:py-8 flex flex-col justify-center gap-5"
+  >
+    <h6 class="text-center md:text-start text-white">
+      深受全球顶尖软件团队信赖
+    </h6>
+  </section>
+  <section class="wrapper wrapper--ticks border-t">
+    <LogoGrid :logos="logos" />
+  </section>
+</template>
+
+<style scoped>
+:deep(img) {
+  filter: brightness(0) invert(1);
+  opacity: 0.7;
+}
+</style>

--- a/.vitepress/theme/composables/sponsor.ts
+++ b/.vitepress/theme/composables/sponsor.ts
@@ -25,17 +25,17 @@ export function useSponsor() {
         items: sponsors.main,
       },
       {
-        tier: 'In partnership with',
+        tier: '特别赞助商',
         size: 'big',
         items: sponsors.partnership,
       },
       {
-        tier: 'Platinum Sponsors',
+        tier: '铂金赞助商',
         size: 'big',
         items: sponsors.platinum,
       },
       {
-        tier: 'Gold Sponsors',
+        tier: '金牌赞助商',
         size: 'medium',
         items: sponsors.gold,
       },


### PR DESCRIPTION
完善首页信赖与赞助商区域的中文翻译：

- 本地覆写 `TrustedBy.vue` 组件，将信赖标题翻译为“深受全球顶尖软件团队信赖”
- 参考 Vitest 中文站，将赞助商级别翻译为“特别赞助商”“铂金赞助商”和“金牌赞助商”